### PR TITLE
Manual XHR response loading

### DIFF
--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -43,20 +43,23 @@ fetchReplacement = (url, callback, replaceContents) ->
   xhr.setRequestHeader 'X-XHR-Referer', referer
 
   xhr.onload = ->
-    triggerEvent 'page:receive'
-
-    if doc = processResponse()
-      nodes = changePage(extractTitleAndBody(doc)..., replaceContents)
-      reflectRedirectedUrl()
-      triggerEvent 'page:load', nodes
-      callback?()
-    else
-      document.location.href = url.absolute
+    loadPage(xhr, onLoadFunction, replaceContents)
 
   xhr.onloadend = -> xhr = null
   xhr.onerror   = -> document.location.href = url.absolute
 
   xhr.send()
+
+loadPage = (xhr, onLoadFunction = (=>), replaceContents = []) ->
+  triggerEvent 'page:receive'
+
+  if doc = processResponse()
+    nodes = changePage(extractTitleAndBody(doc)..., replaceContents)
+    reflectRedirectedUrl(xhr)
+    triggerEvent 'page:load', nodes
+    callback?()
+  else
+    document.location.href = url.absolute
 
 fetchHistory = (cachedPage) ->
   xhr?.abort()
@@ -177,7 +180,7 @@ triggerEvent = (name, data) ->
 pageChangePrevented = ->
   !triggerEvent 'page:before-change'
 
-processResponse = ->
+processResponse = (xhr) ->
   clientOrServerError = ->
     400 <= xhr.status < 600
 
@@ -255,10 +258,10 @@ browserCompatibleDocumentParser = ->
 
 
 # The ComponentUrl class converts a basic URL string into an object
-# that behaves similarly to document.location.  
+# that behaves similarly to document.location.
 #
-# If an instance is created from a relative URL, the current document 
-# is used to fill in the missing attributes (protocol, host, port).  
+# If an instance is created from a relative URL, the current document
+# is used to fill in the missing attributes (protocol, host, port).
 class ComponentUrl
   constructor: (@original = document.location.href) ->
     return @original if @original.constructor is ComponentUrl
@@ -295,18 +298,18 @@ class Link extends ComponentUrl
     super
 
   shouldIgnore: ->
-    @_crossOrigin() or 
-      @_anchored() or 
-      @_nonHtml() or 
-      @_optOut() or 
+    @_crossOrigin() or
+      @_anchored() or
+      @_nonHtml() or
+      @_optOut() or
       @_target()
 
   _crossOrigin: ->
     @origin isnt (new ComponentUrl).origin
-    
+
   _anchored: ->
-    ((@hash and @withoutHash()) is (current = new ComponentUrl).withoutHash()) or 
-      (@href is current.href + '#') 
+    ((@hash and @withoutHash()) is (current = new ComponentUrl).withoutHash()) or
+      (@href is current.href + '#')
 
   _nonHtml: ->
     @pathname.match(/\.[a-z]+$/g) and not @pathname.match(new RegExp("\\.(?:#{Link.HTML_EXTENSIONS.join('|')})?$", 'g'))
@@ -323,9 +326,9 @@ class Link extends ComponentUrl
 
 
 # The Click class handles clicked links, verifying if Turbolinks should
-# take control by inspecting both the event and the link. If it should, 
-# the page change process is initiated. If not, control is passed back 
-# to the browser for default functionality. 
+# take control by inspecting both the event and the link. If it should,
+# the page change process is initiated. If not, control is passed back
+# to the browser for default functionality.
 class Click
   @installHandlerLast: (event) ->
     unless event.defaultPrevented
@@ -340,7 +343,7 @@ class Click
     @_extractLink()
     if @_validForTurbolinks()
       visit @link.href unless pageChangePrevented()
-      @event.preventDefault() 
+      @event.preventDefault()
 
   _extractLink: ->
     link = @event.target
@@ -351,10 +354,10 @@ class Click
     @link? and not (@link.shouldIgnore() or @_nonStandardClick())
 
   _nonStandardClick: ->
-    @event.which > 1 or 
-      @event.metaKey or 
-      @event.ctrlKey or 
-      @event.shiftKey or 
+    @event.which > 1 or
+      @event.metaKey or
+      @event.ctrlKey or
+      @event.shiftKey or
       @event.altKey
 
 
@@ -428,4 +431,4 @@ else
 #   Turbolinks.enableTransitionCache()
 #   Turbolinks.allowLinkExtensions('md')
 #   Turbolinks.supported
-@Turbolinks = { visit, pagesCached, enableTransitionCache, allowLinkExtensions: Link.allowExtensions, supported: browserSupportsTurbolinks }
+@Turbolinks = { visit, pagesCached, enableTransitionCache, allowLinkExtensions: Link.allowExtensions, supported: browserSupportsTurbolinks, loadPage }

--- a/lib/assets/javascripts/turbolinks.js.coffee
+++ b/lib/assets/javascripts/turbolinks.js.coffee
@@ -53,7 +53,7 @@ fetchReplacement = (url, callback, replaceContents) ->
 loadPage = (xhr, onLoadFunction = (=>), replaceContents = []) ->
   triggerEvent 'page:receive'
 
-  if doc = processResponse()
+  if doc = processResponse(xhr)
     nodes = changePage(extractTitleAndBody(doc)..., replaceContents)
     reflectRedirectedUrl(xhr)
     triggerEvent 'page:load', nodes
@@ -141,7 +141,7 @@ reflectNewUrl = (url) ->
   if (url = new ComponentUrl url).absolute isnt referer
     window.history.pushState { turbolinks: true, url: url.absolute }, '', url.absolute
 
-reflectRedirectedUrl = ->
+reflectRedirectedUrl = (xhr) ->
   if location = xhr.getResponseHeader 'X-XHR-Redirected-To'
     location = new ComponentUrl location
     preservedHash = if location.hasNoHash() then document.location.hash else ''


### PR DESCRIPTION
This adds the ability to manually pass the XHR in to turbolinks for parsing the response.

Extends on top of your PR @pushrax 

/cc @arthurnn @kmcphillips @nsimmons 
